### PR TITLE
connectivity changes to YOCTO build

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -28,7 +28,7 @@ LICENSE_FLAGS_WHITELIST += "oracle_java"
 
 IMAGE_INSTALL_append += " mariadb"
 IMAGE_INSTALL_append += " ppp sudo ethtool e2fsprogs"
-IMAGE_INSTALL_append += " networkmanager networkmanager-qt modemmanager polkit consolekit quectel-ppp nano file memtester stress tcpdump minicom openssl gpioscript iptables i2c-tools mtd-utils-ubifs mtd-utils-misc "
+IMAGE_INSTALL_append += " networkmanager networkmanager-qt modemmanager polkit consolekit quectel-ppp nano file memtester stress tcpdump minicom openssl gpioscript iptables i2c-tools mtd-utils-ubifs mtd-utils-misc resolvconf "
 
 # User configuration should be placed below this line
 CORE_IMAGE_EXTRA_INSTALL += "oracle-jse-jre"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -16,10 +16,11 @@ IMAGE_ROOTFS_EXTRA_SPACE = "2097152"
 KERNEL_MODULE_AUTOLOAD += "ads7846"
 IMAGE_INSTALL_append = " hostapd dnsmasq iproute2"
 IMAGE_INSTALL_remove = " msc-wallpaper"
+IMAGE_INSTALL_remove = " connman"
 IMAGE_INSTALL_append = " cronie mysql5"
 IMAGE_INSTALL_append = " python-argparse"
 IMAGE_INSTALL_append = " python-json python-requests python-email python-urllib3 python-pybluez"
-DISTRO_FEATURES_remove += " x11"
+#DISTRO_FEATURES_remove += " x11"
 PACKAGECONFIG_DISTRO_append_pn-qtbase = " accessibility"
 DISTRO_FEATURES_append = " bluetooth bluez5 "
 #In order to build them you need to enable "oracle-java" license
@@ -27,7 +28,7 @@ LICENSE_FLAGS_WHITELIST += "oracle_java"
 
 IMAGE_INSTALL_append += " mariadb"
 IMAGE_INSTALL_append += " ppp sudo ethtool e2fsprogs"
-IMAGE_INSTALL_append += " connman quectel-ppp nano file memtester stress tcpdump minicom openssl gpioscript iptables i2c-tools mtd-utils-ubifs mtd-utils-misc "
+IMAGE_INSTALL_append += " networkmanager networkmanager-qt modemmanager polkit consolekit quectel-ppp nano file memtester stress tcpdump minicom openssl gpioscript iptables i2c-tools mtd-utils-ubifs mtd-utils-misc "
 
 # User configuration should be placed below this line
 CORE_IMAGE_EXTRA_INSTALL += "oracle-jse-jre"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -29,6 +29,8 @@ LICENSE_FLAGS_WHITELIST += "oracle_java"
 IMAGE_INSTALL_append += " mariadb"
 IMAGE_INSTALL_append += " ppp sudo ethtool e2fsprogs"
 IMAGE_INSTALL_append += " networkmanager networkmanager-qt modemmanager polkit consolekit quectel-ppp nano file memtester stress tcpdump minicom openssl gpioscript iptables i2c-tools mtd-utils-ubifs mtd-utils-misc resolvconf "
+IMAGE_INSTALL_append += " ntp"
+
 
 # User configuration should be placed below this line
 CORE_IMAGE_EXTRA_INSTALL += "oracle-jse-jre"

--- a/recipes-connectivity/networkmanager/networkmanager/NetworkManager
+++ b/recipes-connectivity/networkmanager/networkmanager/NetworkManager
@@ -90,7 +90,6 @@ d_stop() {
 case "$1" in
   start)
 	echo "Starting $DESC" "$NAME"
-	rm /dev/ttyUSB2 || true
 	d_start
 	;;
   stop)

--- a/recipes-connectivity/networkmanager/networkmanager/NetworkManager
+++ b/recipes-connectivity/networkmanager/networkmanager/NetworkManager
@@ -83,6 +83,7 @@ d_stop() {
 	start-stop-daemon --stop --retry 5 --quiet --pidfile $PIDFILE \
 		 --oknodo --user $USER --exec $DAEMON
 
+	killall ModemManager
 }
 
 

--- a/recipes-connectivity/networkmanager/networkmanager/NetworkManager
+++ b/recipes-connectivity/networkmanager/networkmanager/NetworkManager
@@ -37,9 +37,6 @@ test -x $DAEMON || exit 0
 
 test -f /etc/default/NetworkManager && . /etc/default/NetworkManager
 
-WIFI_MAC_ADDR="$(ifconfig mlan0 | grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}' | tr ":" "-")"
-echo MAC is $WIFI_MAC_ADDR
-
 #
 #	Function that starts the daemon/service.
 #
@@ -52,28 +49,6 @@ d_start() {
 	start-stop-daemon --start --quiet --pidfile $PIDFILE \
 		--oknodo --user $USER --exec $DAEMON -- $DAEMON_OPTS --pid-file $PIDFILE
 
-	local eth_set="$(nmcli c | grep wired)"
-	echo eth=$eth_set
-	if [ -z "$eth_set" ];
-	then
-		nmcli c add type eth ifname eth0 con-name wired autoconnect yes
-		nmcli c mod wired connection.autoconnect-priority  3
-	fi
-
-	local modem_set="$(nmcli c | grep modem)"
-	echo modem=$modem_set
-	if [ -z "$modem_set" ];
-	then
-		nmcli c add type gsm ifname ttyUSB3 con-name cellular_modem autoconnect yes apn internetg
-		nmcli c mod cellular_modem connection.autoconnect-priority  1
-	fi
-
-	nmcli c delete Hostspot || true
-	nmcli con add type wifi ifname mlan0 con-name Hostspot autoconnect no ssid Netbeat_$WIFI_MAC_ADDR
-	nmcli con modify Hostspot 802-11-wireless.mode ap 802-11-wireless.band bg ipv4.method shared
-	nmcli con modify Hostspot wifi-sec.key-mgmt wpa-psk
-	nmcli con modify Hostspot wifi-sec.psk "password"
-	nmcli con up Hostspot
 }
 
 #
@@ -83,7 +58,7 @@ d_stop() {
 	start-stop-daemon --stop --retry 5 --quiet --pidfile $PIDFILE \
 		 --oknodo --user $USER --exec $DAEMON
 
-	killall ModemManager
+	killall ModemManager || true
 }
 
 

--- a/recipes-connectivity/networkmanager/networkmanager/NetworkManager
+++ b/recipes-connectivity/networkmanager/networkmanager/NetworkManager
@@ -49,8 +49,6 @@ d_start() {
 	start-stop-daemon --start --quiet --pidfile $PIDFILE \
 		--oknodo --user $USER --exec $DAEMON -- $DAEMON_OPTS --pid-file $PIDFILE
 
-	sleep 1
-
 	local eth_set="$(nmcli c | grep wired)"
 	echo eth=$eth_set
 	if [ -z "$eth_set" ];
@@ -80,25 +78,19 @@ d_stop() {
 
 case "$1" in
   start)
-	#log_daemon_msg "Starting $DESC" "$NAME"
 	echo "Starting $DESC" "$NAME"
 	rm /dev/ttyUSB2 || true
 	d_start
-	#log_end_msg $?
 	;;
   stop)
-	#log_daemon_msg "Stopping $DESC" "$NAME"
 	echo "Stopping $DESC" "$NAME"
 	d_stop
-	#log_end_msg $?
 	;;
   restart|force-reload)
-	#log_daemon_msg "Restarting $DESC" "$NAME"
 	echo "Restarting $DESC" "$NAME"
 	d_stop
 	sleep 1
 	d_start
-	#log_end_msg $?
 	;;
   status)
 	status_of_proc -p $PIDFILE $DAEMON $NAME && exit 0 || exit $?

--- a/recipes-connectivity/networkmanager/networkmanager/NetworkManager
+++ b/recipes-connectivity/networkmanager/networkmanager/NetworkManager
@@ -37,6 +37,9 @@ test -x $DAEMON || exit 0
 
 test -f /etc/default/NetworkManager && . /etc/default/NetworkManager
 
+WIFI_MAC_ADDR="$(ifconfig mlan0 | grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}' | tr ":" "-")"
+echo MAC is $WIFI_MAC_ADDR
+
 #
 #	Function that starts the daemon/service.
 #
@@ -64,6 +67,13 @@ d_start() {
 		nmcli c add type gsm ifname ttyUSB3 con-name cellular_modem autoconnect yes apn internetg
 		nmcli c mod cellular_modem connection.autoconnect-priority  1
 	fi
+
+	nmcli c delete Hostspot || true
+	nmcli con add type wifi ifname mlan0 con-name Hostspot autoconnect no ssid Netbeat_$WIFI_MAC_ADDR
+	nmcli con modify Hostspot 802-11-wireless.mode ap 802-11-wireless.band bg ipv4.method shared
+	nmcli con modify Hostspot wifi-sec.key-mgmt wpa-psk
+	nmcli con modify Hostspot wifi-sec.psk "password"
+	nmcli con up Hostspot
 }
 
 #

--- a/recipes-connectivity/networkmanager/networkmanager/NetworkManager.conf
+++ b/recipes-connectivity/networkmanager/networkmanager/NetworkManager.conf
@@ -8,3 +8,6 @@ managed=true
 [logging]
 level=INFO
 
+[keyfile]
+#unmanaged-devices=interface-name:mlan*
+

--- a/recipes-connectivity/networkmanager/networkmanager/NetworkManager.conf
+++ b/recipes-connectivity/networkmanager/networkmanager/NetworkManager.conf
@@ -1,0 +1,10 @@
+[main]
+dhcp=dhclient
+plugins=ifupdown,keyfile
+
+[ifupdown]
+managed=true
+
+[logging]
+level=INFO
+

--- a/recipes-connectivity/networkmanager/networkmanager/NetworkManager.in
+++ b/recipes-connectivity/networkmanager/networkmanager/NetworkManager.in
@@ -1,0 +1,113 @@
+#! /bin/sh
+### BEGIN INIT INFO
+# Provides:          NetworkManager
+# Required-Start:    $remote_fs dbus hal
+# Required-Stop:     $remote_fs dbus hal
+# Should-Start:	     $syslog
+# Should-Stop:       $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: network connection manager
+# Description:       Daemon for automatically switching network
+#                    connections to the best available connection.
+### END INIT INFO
+
+set -e
+
+prefix=/usr
+exec_prefix=/usr
+sbindir=/usr/sbin
+localstatedir=/var
+
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+DESC="network connection manager"
+NAME="NetworkManager"
+
+DAEMON=${sbindir}/$NAME
+
+PIDDIR=${localstatedir}/run/NetworkManager
+PIDFILE=$PIDDIR/$NAME.pid
+
+USER=root
+
+# Gracefully exit if the package has been removed.
+test -x $DAEMON || exit 0
+
+#. /lib/lsb/init-functions
+
+test -f /etc/default/NetworkManager && . /etc/default/NetworkManager
+
+#
+#	Function that starts the daemon/service.
+#
+d_start() {
+	if [ ! -d $PIDDIR ]; then
+		mkdir -p $PIDDIR
+		chown $USER:$USER $PIDDIR
+	fi
+
+	start-stop-daemon --start --quiet --pidfile $PIDFILE \
+		--oknodo --user $USER --exec $DAEMON -- $DAEMON_OPTS --pid-file $PIDFILE
+
+	sleep 1
+
+	local eth_set="$(nmcli c | grep wired)"
+	echo eth=$eth_set
+	if [ -z "$eth_set" ];
+	then
+		nmcli c add type eth ifname eth0 con-name wired autoconnect yes
+		nmcli c mod wired connection.autoconnect-priority  3
+	fi
+
+	local modem_set="$(nmcli c | grep modem)"
+	echo modem=$modem_set
+	if [ -z "$modem_set" ];
+	then
+		nmcli c add type gsm ifname ttyUSB3 con-name cellular_modem autoconnect yes apn internetg
+		nmcli c mod cellular_modem connection.autoconnect-priority  1
+	fi
+}
+
+#
+#	Function that stops the daemon/service.
+#
+d_stop() {
+	start-stop-daemon --stop --retry 5 --quiet --pidfile $PIDFILE \
+		 --oknodo --user $USER --exec $DAEMON
+
+}
+
+
+case "$1" in
+  start)
+	#log_daemon_msg "Starting $DESC" "$NAME"
+	echo "Starting $DESC" "$NAME"
+	rm /dev/ttyUSB2 || true
+	d_start
+	#log_end_msg $?
+	;;
+  stop)
+	#log_daemon_msg "Stopping $DESC" "$NAME"
+	echo "Stopping $DESC" "$NAME"
+	d_stop
+	#log_end_msg $?
+	;;
+  restart|force-reload)
+	#log_daemon_msg "Restarting $DESC" "$NAME"
+	echo "Restarting $DESC" "$NAME"
+	d_stop
+	sleep 1
+	d_start
+	#log_end_msg $?
+	;;
+  status)
+	status_of_proc -p $PIDFILE $DAEMON $NAME && exit 0 || exit $?
+	;;
+  *)
+	echo "Usage: $0 {start|stop|restart|force-reload|status}" >&2
+	exit 1
+	;;
+esac
+
+exit 0
+

--- a/recipes-connectivity/networkmanager/networkmanager/interfaces
+++ b/recipes-connectivity/networkmanager/networkmanager/interfaces
@@ -1,0 +1,6 @@
+# /etc/network/interfaces -- configuration file for ifup(8), ifdown(8)
+ 
+# The loopback interface
+auto lo
+iface lo inet loopback
+

--- a/recipes-connectivity/networkmanager/networkmanager/nm_monitor
+++ b/recipes-connectivity/networkmanager/networkmanager/nm_monitor
@@ -5,7 +5,31 @@
 #                    connections.
 ### END INIT INFO
 
+
+CFG_FILE=/netatim/network-settings/ipsettingsparams.cfg
+
+NM_DAEMON=/etc/init.d/NetworkManager
+
+NM_SYSCON_DEV_CELL=ttyUSB3
+NM_SYSCON_NAME_CELL=cellular_modem
+NM_SYSCON_DEV_WIFIAP=mlan0
+NM_SYSCON_NAME_WIFIAP=Hostspot
+NM_SYSCON_DEV_ETH=eth0
+NM_SYSCON_NAME_ETH=Wired
+
 PINGISOK=0
+WIFI_MAC_ADDR=''
+RETRYCOUNTER=0
+
+#default configuration in case CFG_FILE not exist
+CELL_ADDRESS='internetg'
+CELL_USER=''
+CELL_PASS=''
+APN_SSIDNAME=Netbeat_00-30-d6-1a-74-8a
+ACCESSPASS='password'
+CHANNEL='6'
+MLANSTATIC='19.168.1.1'
+DHCP_RANGE='19.168.1.50,19.168.1.150,12h'
 
 validate_network() {
 	local pingresult="$(timeout 3 ping google.com -c 3 | grep "time=")"
@@ -17,9 +41,79 @@ validate_network() {
 	fi
 }
 
-echo ==== NM monitor ===
+wait_nm() {
+	RETRYCOUNTER=0
+	nm-online -t 3
+	local ret=$?
+	while [ $ret -ne 0 ] && [  $RETRYCOUNTER -lt 5 ];
+	do
+		# if network manager is not online, make sure to execute it
+		echo "Network manager not ready $RETRYCOUNTER , ($ret)"
+		$NM_DAEMON restart
+		nm-online -t 3
+		ret=$?
+		let "RETRYCOUNTER++"
+	done
 
-RETRYCOUNTER=0
+	if [  $RETRYCOUNTER -eq 5 ];
+	then
+		echo "ERROR: Network manager can't run"
+		exit
+	else
+		echo "Network manager running"
+	fi
+}
+
+configure_nm() {
+	echo "Configure networkmanager connections"
+	# if configuration file does not exist then use default defined above
+	if [ -f $CFG_FILE ];
+	then
+		echo "Load configuration file"
+		source $CFG_FILE
+	else
+		echo "Configuration file not exist"
+	fi
+
+	check_wired_interface
+	configure_nm_cellular
+	configure_nm_wifiap
+}
+
+check_wired_interface() {
+	local wired_set="$(nmcli c | grep wired)"
+	echo eth=$wired_set
+	if [ -z "$wired_set" ];
+	then
+		nmcli c add type eth ifname eth0 con-name wired autoconnect yes
+		nmcli c mod wired connection.autoconnect-priority  3
+	fi
+}
+
+configure_nm_cellular() {
+	echo configuring cellular connection
+	#make sure to delete the cellular connetion before configuring a new one
+	nmcli c delete $NM_SYSCON_NAME_CELL || true
+	nmcli c add type gsm ifname $NM_SYSCON_DEV_CELL con-name $NM_SYSCON_NAME_CELL autoconnect yes apn $CELL_ADDRESS
+	nmcli c mod $NM_SYSCON_NAME_CELL connection.autoconnect-priority  1
+}
+
+configure_nm_wifiap() {
+	nmcli c delete Hostspot || true
+	nmcli con add type wifi ifname mlan0 con-name Hostspot autoconnect no ssid Netbeat_$WIFI_MAC_ADDR
+	nmcli con modify Hostspot 802-11-wireless.mode ap 802-11-wireless.band bg ipv4.method shared
+	nmcli con modify Hostspot wifi-sec.key-mgmt wpa-psk
+	nmcli con modify Hostspot wifi-sec.psk "password"
+	nmcli con up Hostspot
+}
+
+echo ==== NM monitor ===
+WIFI_MAC_ADDR="$(ifconfig mlan0 | grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}' | tr ":" "-")"
+echo MAC is $WIFI_MAC_ADDR
+
+wait_nm
+configure_nm
+
 while [ 1 ]; do
 	sleep 4
 	validate_network
@@ -38,7 +132,7 @@ while [ 1 ]; do
 
 	if [ $PINGISOK -ne 1 ]; then
 		echo Restart NM
-		/etc/init.d/NetworkManager restart
+		$NM_DAEMON restart
 	fi
 done
 

--- a/recipes-connectivity/networkmanager/networkmanager/nm_monitor
+++ b/recipes-connectivity/networkmanager/networkmanager/nm_monitor
@@ -43,36 +43,36 @@ validate_network() {
 
 wait_nm() {
 	RETRYCOUNTER=0
-	nm-online -t 3
+	nm-online -t 5
 	local ret=$?
 	while [ $ret -ne 0 ] && [  $RETRYCOUNTER -lt 5 ];
 	do
 		# if network manager is not online, make sure to execute it
-		echo "Network manager not ready $RETRYCOUNTER , ($ret)"
+		echo "Network manager not ready $RETRYCOUNTER , ($ret)"  >> /tmp/nm_log
 		$NM_DAEMON restart
-		nm-online -t 3
+		nm-online -t 5
 		ret=$?
 		let "RETRYCOUNTER++"
 	done
 
 	if [  $RETRYCOUNTER -eq 5 ];
 	then
-		echo "ERROR: Network manager can't run"
+		echo "ERROR: Network manager can't run" >> /tmp/nm_log
 		exit
 	else
-		echo "Network manager running"
+		echo "Network manager running"  >> /tmp/nm_log
 	fi
 }
 
 configure_nm() {
-	echo "Configure networkmanager connections"
+	echo "Configure networkmanager connections"  >> /tmp/nm_log
 	# if configuration file does not exist then use default defined above
 	if [ -f $CFG_FILE ];
 	then
-		echo "Load configuration file"
+		echo "Load configuration file"  >> /tmp/nm_log
 		source $CFG_FILE
 	else
-		echo "Configuration file not exist"
+		echo "Configuration file not exist"  >> /tmp/nm_log
 	fi
 
 	check_wired_interface
@@ -82,7 +82,7 @@ configure_nm() {
 
 check_wired_interface() {
 	local wired_set="$(nmcli c | grep wired)"
-	echo eth=$wired_set
+	echo eth=$wired_set  >> /tmp/nm_log
 	if [ -z "$wired_set" ];
 	then
 		nmcli c add type eth ifname eth0 con-name wired autoconnect yes
@@ -91,11 +91,26 @@ check_wired_interface() {
 }
 
 configure_nm_cellular() {
-	echo configuring cellular connection
-	#make sure to delete the cellular connetion before configuring a new one
+	echo configuring cellular connection  >> /tmp/nm_log
+	# make sure to delete the cellular connetion before configuring a new one
 	nmcli c delete $NM_SYSCON_NAME_CELL || true
 	nmcli c add type gsm ifname $NM_SYSCON_DEV_CELL con-name $NM_SYSCON_NAME_CELL autoconnect yes apn $CELL_ADDRESS
 	nmcli c mod $NM_SYSCON_NAME_CELL connection.autoconnect-priority  1
+
+	# cellular APN settings, make sure how to use user/pass if needed or not
+	if [ ! -z $CELL_USER ];
+	then
+		nmcli c mod $NM_SYSCON_NAME_CELL gsm.username $CELL_USER
+		if [ ! -z $CELL_PASS ];
+		then
+			echo cellular need user and a passowrd  >> /tmp/nm_log
+			nmcli c mod $NM_SYSCON_NAME_CELL gsm.password $CELL_PASS
+		else
+			echo cellular need both user without passowrd  >> /tmp/nm_log
+		fi
+	else
+		echo cellular does not need user and password >> /tmp/nm_log
+	fi
 }
 
 configure_nm_wifiap() {
@@ -107,9 +122,9 @@ configure_nm_wifiap() {
 	nmcli con up Hostspot
 }
 
-echo ==== NM monitor ===
+echo ==== NM monitor ===  > /tmp/nm_log
 WIFI_MAC_ADDR="$(ifconfig mlan0 | grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}' | tr ":" "-")"
-echo MAC is $WIFI_MAC_ADDR
+echo MAC is $WIFI_MAC_ADDR  >> /tmp/nm_log
 
 wait_nm
 configure_nm
@@ -123,7 +138,7 @@ while [ 1 ]; do
 		RETRYCOUNTER=0
 		while [ $PINGISOK -ne 1 ] && [  $RETRYCOUNTER -lt 3 ]; do
 			sleep 3
-			echo Recheck network connection: $RETRYCOUNTER
+			echo Recheck network connection: $RETRYCOUNTER   >> /tmp/nm_log
 			validate_network
 			let "RETRYCOUNTER++"
 		done
@@ -131,7 +146,7 @@ while [ 1 ]; do
 	fi
 
 	if [ $PINGISOK -ne 1 ]; then
-		echo Restart NM
+		echo Restart NM  >> /tmp/nm_log
 		$NM_DAEMON restart
 	fi
 done

--- a/recipes-connectivity/networkmanager/networkmanager/nm_monitor
+++ b/recipes-connectivity/networkmanager/networkmanager/nm_monitor
@@ -18,9 +18,6 @@ validate_network() {
 }
 
 echo ==== NM monitor ===
-sleep 20
-echo ==== NM Start ===
-/etc/init.d/NetworkManager start
 
 RETRYCOUNTER=0
 while [ 1 ]; do

--- a/recipes-connectivity/networkmanager/networkmanager/nm_monitor
+++ b/recipes-connectivity/networkmanager/networkmanager/nm_monitor
@@ -114,16 +114,17 @@ configure_nm_cellular() {
 }
 
 configure_nm_wifiap() {
-	nmcli c delete Hostspot || true
-	nmcli con add type wifi ifname mlan0 con-name Hostspot autoconnect no ssid Netbeat_$WIFI_MAC_ADDR
-	nmcli con modify Hostspot 802-11-wireless.mode ap 802-11-wireless.band bg ipv4.method shared
-	nmcli con modify Hostspot wifi-sec.key-mgmt wpa-psk
-	nmcli con modify Hostspot wifi-sec.psk "password"
+	nmcli c delete $NM_SYSCON_NAME_WIFIAP || true
+	nmcli con add type wifi ifname mlan0 con-name $NM_SYSCON_NAME_WIFIAP autoconnect no ssid Netbeat_$WIFI_MAC_ADDR
+	nmcli con modify $NM_SYSCON_NAME_WIFIAP 802-11-wireless.mode ap 802-11-wireless.band bg ipv4.method shared
+	nmcli con modify $NM_SYSCON_NAME_WIFIAP wifi-sec.key-mgmt wpa-psk
+	nmcli con modify $NM_SYSCON_NAME_WIFIAP wifi-sec.psk $ACCESSPASS
+	nmcli connection modify $NM_SYSCON_NAME_WIFIAP ipv4.addresses 19.168.2.5/24
 	nmcli con up Hostspot
 }
 
 echo ==== NM monitor ===  > /tmp/nm_log
-WIFI_MAC_ADDR="$(ifconfig mlan0 | grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}' | tr ":" "-")"
+WIFI_MAC_ADDR="$(ifconfig eth0 | grep -o -E '([[:xdigit:]]{1,2}:){5}[[:xdigit:]]{1,2}' | tr ":" "-")"
 echo MAC is $WIFI_MAC_ADDR  >> /tmp/nm_log
 
 wait_nm

--- a/recipes-connectivity/networkmanager/networkmanager/nm_monitor
+++ b/recipes-connectivity/networkmanager/networkmanager/nm_monitor
@@ -1,0 +1,47 @@
+#! /bin/sh
+### BEGIN INIT INFO
+# Short-Description: NetworkManager monitor
+# Description:       Daemon for automatically check network
+#                    connections.
+### END INIT INFO
+
+PINGISOK=0
+
+validate_network() {
+	local pingresult="$(timeout 3 ping google.com -c 3 | grep "time=")"
+	if [ -z "$pingresult" ];
+	then
+		PINGISOK=0
+	else
+		PINGISOK=1
+	fi
+}
+
+echo ==== NM monitor ===
+sleep 20
+RETRYCOUNTER=0
+while [ 1 ]; do
+	sleep 4
+	validate_network
+	if [ $PINGISOK -eq 1 ]; then
+		continue
+	else
+		RETRYCOUNTER=0
+		while [ $PINGISOK -ne 1 ] && [  $RETRYCOUNTER -lt 3 ]; do
+			sleep 3
+			echo Recheck network connection: $RETRYCOUNTER
+			validate_network
+			let "RETRYCOUNTER++"
+		done
+
+	fi
+
+	if [ $PINGISOK -ne 1 ]; then
+		echo Restart NM
+		/etc/init.d/NetworkManager.in restart
+	fi
+done
+
+exit 0
+
+

--- a/recipes-connectivity/networkmanager/networkmanager/nm_monitor
+++ b/recipes-connectivity/networkmanager/networkmanager/nm_monitor
@@ -19,6 +19,9 @@ validate_network() {
 
 echo ==== NM monitor ===
 sleep 20
+echo ==== NM Start ===
+/etc/init.d/NetworkManager start
+
 RETRYCOUNTER=0
 while [ 1 ]; do
 	sleep 4
@@ -38,7 +41,7 @@ while [ 1 ]; do
 
 	if [ $PINGISOK -ne 1 ]; then
 		echo Restart NM
-		/etc/init.d/NetworkManager.in restart
+		/etc/init.d/NetworkManager restart
 	fi
 done
 

--- a/recipes-connectivity/networkmanager/networkmanager/nm_runner
+++ b/recipes-connectivity/networkmanager/networkmanager/nm_runner
@@ -11,8 +11,33 @@
 # Description:       Daemon for network manager monitorring
 ### END INIT INFO
 
+NM_SYSCON_DEV_CELL=/dev/ttyUSB3
+NM_SYSCON_DEV_WIFIAP=mlan0
+
 #update-rc.d -f hostapd remove
 #update-rc.d -f dnsmasq remove
+
+delete_usb2() {
+	if [ -c "/dev/ttyUSB2" ]; then
+		echo "Delete ttyUSB2"
+		rm /dev/ttyUSB2
+	fi
+}
+
+wait_hw() {
+	while [ ! -c $NM_SYSCON_DEV_CELL ];
+	do
+		echo "$NM_SYSCON_DEV_CELL not exist yet"
+		sleep 1;
+	done
+	echo "$NM_SYSCON_DEV_CELL is exist"
+
+	while [ -z "$(ifconfig $NM_SYSCON_DEV_WIFIAP)" ]; do
+		echo "$NM_SYSCON_DEV_WIFIAP not exist yet"
+		sleep 1;
+	done
+	echo "$NM_SYSCON_DEV_WIFIAP is exist"
+}
 
 
 set -e
@@ -63,6 +88,8 @@ nm_stop() {
 
 case "$1" in
   start)
+	wait_hw
+	delete_usb2
 	echo "Starting" "$NAME"
 	nm_start
 	;;

--- a/recipes-connectivity/networkmanager/networkmanager/nm_runner
+++ b/recipes-connectivity/networkmanager/networkmanager/nm_runner
@@ -1,5 +1,8 @@
 #! /bin/sh
 
+update-rc.d -f hostapd remove
+update-rc.d -f dnsmasq remove
+
 case "$1" in
   start)
 	echo "Starting nm_monitor"

--- a/recipes-connectivity/networkmanager/networkmanager/nm_runner
+++ b/recipes-connectivity/networkmanager/networkmanager/nm_runner
@@ -14,8 +14,9 @@
 NM_SYSCON_DEV_CELL=/dev/ttyUSB3
 NM_SYSCON_DEV_WIFIAP=mlan0
 
-#update-rc.d -f hostapd remove
-#update-rc.d -f dnsmasq remove
+update-rc.d -f hostapd remove
+update-rc.d -f dnsmasq remove
+ln -sf /usr/lib/jvm/java-8-oracle/jre/bin/java /usr/bin/java
 
 delete_usb2() {
 	if [ -c "/dev/ttyUSB2" ]; then
@@ -74,6 +75,7 @@ nm_start() {
 
 	start-stop-daemon --start --quiet --pidfile $PIDFILE --oknodo --background  \
 		--user $USER --make-pidfile --exec $DAEMON
+	echo "=== Monitor daemon started ==="
 }
 
 nm_stop() {
@@ -88,6 +90,7 @@ nm_stop() {
 
 case "$1" in
   start)
+	sleep 10
 	wait_hw
 	delete_usb2
 	echo "Starting" "$NAME"

--- a/recipes-connectivity/networkmanager/networkmanager/nm_runner
+++ b/recipes-connectivity/networkmanager/networkmanager/nm_runner
@@ -1,22 +1,86 @@
 #! /bin/sh
+### BEGIN INIT INFO
+# Provides:          nm_monitor
+# Required-Start:    $remote_fs dbus hal
+# Required-Stop:     $remote_fs dbus hal
+# Should-Start:.     $syslog
+# Should-Stop:       $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: network connection monitor
+# Description:       Daemon for network manager monitorring
+### END INIT INFO
 
-update-rc.d -f hostapd remove
-update-rc.d -f dnsmasq remove
+#update-rc.d -f hostapd remove
+#update-rc.d -f dnsmasq remove
+
+
+set -e
+
+prefix=/usr
+exec_prefix=/usr
+sbindir=/usr/sbin
+localstatedir=/var
+
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+DESC="network manager monitor"
+NAME="nm_monitor"
+
+DAEMON=${sbindir}/$NAME
+
+PIDDIR=${localstatedir}/run/nm_monitor
+PIDFILE=$PIDDIR/$NAME.pid
+
+USER=root
+
+echo ==== NM runner ===
+
+# Gracefully exit if the package has been removed.
+test -x $DAEMON || exit 0
+
+nm_start() {
+	echo ==== NM Start ===
+	/etc/init.d/NetworkManager start
+
+	if [ ! -d $PIDDIR ]; then
+		mkdir -p $PIDDIR
+		chown $USER:$USER $PIDDIR
+	fi
+
+	start-stop-daemon --start --quiet --pidfile $PIDFILE --oknodo --background  \
+		--user $USER --make-pidfile --exec $DAEMON
+}
+
+nm_stop() {
+	start-stop-daemon --stop --retry 5 --quiet --pidfile $PIDFILE --oknodo  \
+		--user $USER --exec $DAEMON
+	rm -f $PIDFILE
+	killall nm_monitor  || true
+
+	echo ==== NM Stop ===
+	/etc/init.d/NetworkManager stop
+}
 
 case "$1" in
   start)
-	echo "Starting nm_monitor"
-	/etc/init.d/nm_monitor &
+	echo "Starting" "$NAME"
+	nm_start
 	;;
   stop)
-	echo "Stopping nm_monitor"
-	killall nm_monitor
+	echo "Stopping"  "$NAME"
+	nm_stop
+	;;
+  restart)
+	echo "Restarting" "$NAME"
+	nm_stop
+	sleep 1
+	nm_start
 	;;
   status)
 	ps | grep  nm_monitor
 	;;
   *)
-	echo "Usage: $0 {start|stop|status}" >&2
+	echo "Usage: $0 {start|stop|restart|status}" >&2
 	exit 1
 	;;
 esac

--- a/recipes-connectivity/networkmanager/networkmanager/nm_runner
+++ b/recipes-connectivity/networkmanager/networkmanager/nm_runner
@@ -1,0 +1,22 @@
+#! /bin/sh
+
+case "$1" in
+  start)
+	echo "Starting nm_monitor"
+	/etc/init.d/nm_monitor &
+	;;
+  stop)
+	echo "Stopping nm_monitor"
+	killall nm_monitor
+	;;
+  status)
+	ps | grep  nm_monitor
+	;;
+  *)
+	echo "Usage: $0 {start|stop|status}" >&2
+	exit 1
+	;;
+esac
+
+exit 0
+

--- a/recipes-connectivity/networkmanager/networkmanager_1.0.12.bbappend
+++ b/recipes-connectivity/networkmanager/networkmanager_1.0.12.bbappend
@@ -28,14 +28,15 @@ do_install_append() {
      install -m 644   ${WORKDIR}/NetworkManager.conf       ${D}${sysconfdir}/NetworkManager/
      install -m 644   ${WORKDIR}/interfaces                ${D}${sysconfdir}/network/
 
-     install -d ${D}${sysconfdir}/init.d
-     install -m 0755 ${WORKDIR}/NetworkManager      ${D}${sysconfdir}/init.d/
+     install -d ${D}${sbindir}
+     install -m 0755 ${WORKDIR}/nm_monitor      ${D}${sbindir}
 
-     install -m 0755 ${WORKDIR}/nm_monitor      ${D}${sysconfdir}/init.d/
+     install -d ${D}${sysconfdir}/init.d
+     install -m 0755 ${WORKDIR}/NetworkManager ${D}${sysconfdir}/init.d/
      install -m 0755 ${WORKDIR}/nm_runner      ${D}${sysconfdir}/init.d/
      update-rc.d -r ${D} nm_runner start 99 2 3 4 5 .
      update-rc.d -r ${D} nm_runner stop  99 0 1 6 .
 
-     update-rc.d -f hostapd remove
-     update-rc.d -f dnsmasq remove
+     update-rc.d -r ${D} -f hostapd remove .
+     update-rc.d -r ${D} -f dnsmasq remove .
 }

--- a/recipes-connectivity/networkmanager/networkmanager_1.0.12.bbappend
+++ b/recipes-connectivity/networkmanager/networkmanager_1.0.12.bbappend
@@ -4,19 +4,39 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 SRC_URI += " \
      file://NetworkManager.conf \
      file://interfaces \
+     file://NetworkManager.in \
+     file://nm_monitor \
+     file://nm_runner \
  "
 
 DEPENDS += " ppp wireless-tools"
 
 PACKAGECONFIG += " ppp"
 PACKAGECONFIG += " wifi"
+PACKAGECONFIG += " ifupdown"
+PACKAGECONFIG += " dhclient"
 
 EXTRA_OECONF_append = " \
     --with-nmcli=yes \
 "
 
+# these 3 lines will have the script run on boot
+inherit update-rc.d
+INITSCRIPT_PACKAGES = "${PN}"
+INITSCRIPT_NAME = "NetworkManager.in"
+
 do_install_append() {
      install -d ${D}${sysconfdir}/network
      install -m 644   ${WORKDIR}/NetworkManager.conf       ${D}${sysconfdir}/NetworkManager/
      install -m 644   ${WORKDIR}/interfaces                ${D}${sysconfdir}/network/
+
+     install -d ${D}${sysconfdir}/init.d
+     install -m 0755 ${WORKDIR}/NetworkManager.in      ${D}${sysconfdir}/init.d/
+     update-rc.d -r ${D} NetworkManager.in start 20 2 3 4 5 .
+     update-rc.d -r ${D} NetworkManager.in stop  20 0 1 6 .
+
+     install -m 0755 ${WORKDIR}/nm_monitor      ${D}${sysconfdir}/init.d/
+     install -m 0755 ${WORKDIR}/nm_runner      ${D}${sysconfdir}/init.d/
+     update-rc.d -r ${D} nm_runner start 99 2 3 4 5 .
+     update-rc.d -r ${D} nm_runner stop  99 0 1 6 .
 }

--- a/recipes-connectivity/networkmanager/networkmanager_1.0.12.bbappend
+++ b/recipes-connectivity/networkmanager/networkmanager_1.0.12.bbappend
@@ -4,7 +4,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 SRC_URI += " \
      file://NetworkManager.conf \
      file://interfaces \
-     file://NetworkManager.in \
+     file://NetworkManager \
      file://nm_monitor \
      file://nm_runner \
  "
@@ -29,12 +29,13 @@ do_install_append() {
      install -m 644   ${WORKDIR}/interfaces                ${D}${sysconfdir}/network/
 
      install -d ${D}${sysconfdir}/init.d
-     install -m 0755 ${WORKDIR}/NetworkManager.in      ${D}${sysconfdir}/init.d/
-     update-rc.d -r ${D} NetworkManager.in start 20 2 3 4 5 .
-     update-rc.d -r ${D} NetworkManager.in stop  20 0 1 6 .
+     install -m 0755 ${WORKDIR}/NetworkManager      ${D}${sysconfdir}/init.d/
 
      install -m 0755 ${WORKDIR}/nm_monitor      ${D}${sysconfdir}/init.d/
      install -m 0755 ${WORKDIR}/nm_runner      ${D}${sysconfdir}/init.d/
      update-rc.d -r ${D} nm_runner start 99 2 3 4 5 .
      update-rc.d -r ${D} nm_runner stop  99 0 1 6 .
+
+     update-rc.d -f hostapd remove
+     update-rc.d -f dnsmasq remove
 }

--- a/recipes-connectivity/networkmanager/networkmanager_1.0.12.bbappend
+++ b/recipes-connectivity/networkmanager/networkmanager_1.0.12.bbappend
@@ -1,0 +1,10 @@
+
+DEPENDS += " ppp wireless-tools"
+
+PACKAGECONFIG += " ppp"
+PACKAGECONFIG += " wifi"
+
+EXTRA_OECONF_append = " \
+    --with-nmcli=yes \
+"
+

--- a/recipes-connectivity/networkmanager/networkmanager_1.0.12.bbappend
+++ b/recipes-connectivity/networkmanager/networkmanager_1.0.12.bbappend
@@ -13,8 +13,6 @@ DEPENDS += " ppp wireless-tools"
 
 PACKAGECONFIG += " ppp"
 PACKAGECONFIG += " wifi"
-PACKAGECONFIG += " ifupdown"
-PACKAGECONFIG += " dhclient"
 
 EXTRA_OECONF_append = " \
     --with-nmcli=yes \

--- a/recipes-connectivity/networkmanager/networkmanager_1.0.12.bbappend
+++ b/recipes-connectivity/networkmanager/networkmanager_1.0.12.bbappend
@@ -1,4 +1,11 @@
 
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += " \
+     file://NetworkManager.conf \
+     file://interfaces \
+ "
+
 DEPENDS += " ppp wireless-tools"
 
 PACKAGECONFIG += " ppp"
@@ -8,3 +15,8 @@ EXTRA_OECONF_append = " \
     --with-nmcli=yes \
 "
 
+do_install_append() {
+     install -d ${D}${sysconfdir}/network
+     install -m 644   ${WORKDIR}/NetworkManager.conf       ${D}${sysconfdir}/NetworkManager/
+     install -m 644   ${WORKDIR}/interfaces                ${D}${sysconfdir}/network/
+}

--- a/recipes-devtools/packagekit/packagekit_0.5.6.bbappend
+++ b/recipes-devtools/packagekit/packagekit_0.5.6.bbappend
@@ -1,0 +1,10 @@
+
+EXTRA_OECONF = "--with-security-framework=dummy \
+                 --disable-qt \
+                 --disable-gstreamer-plugin \
+                 --disable-local  \
+                 --enable-networkmanager \
+                 --disable-device-rebind \
+                 ac_cv_path_XMLTO=no \
+"
+

--- a/recipes-support/ntp/ntp/ntp.conf
+++ b/recipes-support/ntp/ntp/ntp.conf
@@ -1,0 +1,22 @@
+# This is the most basic ntp configuration file
+# The driftfile must remain in a place specific to this
+# machine - it records the machine specific clock error
+driftfile /var/lib/ntp/drift
+# This should be a server that is close (in IP terms)
+# to the machine.  Add other servers as required.
+# Unless you un-comment the line below ntpd will sync
+# only against the local system clock.
+#
+# server time.server.example.com
+#
+# Using local hardware clock as fallback
+# Disable this when using ntpd -q -g -x as ntpdate or it will sync to itself
+#server 127.127.1.0
+#fudge 127.127.1.0 stratum 14
+
+server 0.pool.ntp.org
+server 1.pool.ntp.org
+server 2.pool.ntp.org
+
+# Defining a default security setting
+restrict default

--- a/recipes-support/ntp/ntp_4.2.8p8.bbappend
+++ b/recipes-support/ntp/ntp_4.2.8p8.bbappend
@@ -1,0 +1,15 @@
+# Replace file /etc/ntp.conf
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += " \
+     file://ntp.conf \
+ "
+
+do_install_append() {
+    install -m 644 ${WORKDIR}/ntp.conf ${D}${sysconfdir}
+
+}
+
+
+


### PR DESCRIPTION
this patchset set NetworkManager as the main networking/connectivity manager instead of connman.
default connections are for eth and ppp modem.
hotspot is set to default load at 19.168.1.1.
Also NTP solution is based on ntpd.

configuration path for netbeat application remains the same.