### PR TITLE
ntp: add cronjob to update hw clock

### DIFF
--- a/recipes-support/ntp/ntp/hw_clock
+++ b/recipes-support/ntp/ntp/hw_clock
@@ -1,0 +1,2 @@
+* *     * * *     root   /sbin/hwclock -w
+

--- a/recipes-support/ntp/ntp_4.2.8p8.bbappend
+++ b/recipes-support/ntp/ntp_4.2.8p8.bbappend
@@ -4,12 +4,15 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 SRC_URI += " \
      file://ntp.conf \
+     file://hw_clock \
  "
 
 do_install_append() {
     install -m 644 ${WORKDIR}/ntp.conf ${D}${sysconfdir}
+    install -d ${D}${sysconfdir}/cron.d
+    install -m 644 ${WORKDIR}/hw_clock ${D}${sysconfdir}/cron.d
 
 }
 
-
+FILES_${PN} += " ${sysconfdir}/cron.d/hw_clock "
 


### PR DESCRIPTION
add a cronjob that will update the hw clock every minute.
due to system time may be set in several use cases (ntp, manual, app),
and hw clock may drift from actuall system clock we must keep it
alinged as much as possible - we do that by using a cronjob every minute
to cover all cases including drifting.

Signed-off-by: Ido Reis <ido.reis@tandemg.com>